### PR TITLE
Add FlashAgent for flashcard generation

### DIFF
--- a/flash_agent.py
+++ b/flash_agent.py
@@ -64,13 +64,20 @@ def main():
     parser = argparse.ArgumentParser(description='FlashAgent CLI')
     subparsers = parser.add_subparsers(dest='command')
 
-    subparsers.add_parser('summarize')
-    subparsers.add_parser('generate')
-    subparsers.add_parser('export')
+    summarize_parser = subparsers.add_parser('summarize')
+    generate_parser = subparsers.add_parser('generate')
+    export_parser = subparsers.add_parser('export')
 
-    parser.add_argument('--notes', default='notes', help='Path to notes directory')
-    parser.add_argument('--json', default='flashcards.json', help='Output JSON file')
-    parser.add_argument('--md', default='flashcards.md', help='Output Markdown file')
+    # Add --notes to all subparsers
+    summarize_parser.add_argument('--notes', default='notes', help='Path to notes directory')
+    generate_parser.add_argument('--notes', default='notes', help='Path to notes directory')
+    export_parser.add_argument('--notes', default='notes', help='Path to notes directory')
+
+    # Add --json and --md only to generate and export
+    generate_parser.add_argument('--json', default='flashcards.json', help='Output JSON file')
+    generate_parser.add_argument('--md', default='flashcards.md', help='Output Markdown file')
+    export_parser.add_argument('--json', default='flashcards.json', help='Output JSON file')
+    export_parser.add_argument('--md', default='flashcards.md', help='Output Markdown file')
 
     args = parser.parse_args()
     agent = FlashAgent(Path(args.notes))

--- a/flash_agent.py
+++ b/flash_agent.py
@@ -50,10 +50,10 @@ class FlashAgent:
                 f.write(f"### {card['concept']}\n{card['definition']}\n\n")
 
     def summarize(self):
-        summary = {}
-        for concept, defs in self.parse_notes().items():
-            summary[concept] = defs[0][:100] + ('...' if len(defs[0]) > 100 else '')
-        return summary
+        return {
+            concept: defs[0][:100] + ('...' if len(defs[0]) > 100 else '')
+            for concept, defs in self.parse_notes().items()
+        }
 
     def print_log(self):
         for msg in self.log_messages:

--- a/flash_agent.py
+++ b/flash_agent.py
@@ -1,0 +1,90 @@
+import argparse
+import json
+from pathlib import Path
+from collections import defaultdict
+
+class FlashAgent:
+    def __init__(self, notes_dir: Path):
+        self.notes_dir = notes_dir
+        self.flashcards = []
+        self.log_messages = []
+
+    def parse_notes(self):
+        headings = defaultdict(list)
+        for path in self.notes_dir.rglob('*.md'):
+            current_heading = None
+            current_content = []
+            for line in path.read_text(encoding='utf-8').splitlines():
+                if line.startswith('#'):
+                    if current_heading is not None:
+                        headings[current_heading].append('\n'.join(current_content).strip())
+                    current_heading = line.lstrip('#').strip()
+                    current_content = []
+                else:
+                    current_content.append(line)
+            if current_heading is not None:
+                headings[current_heading].append('\n'.join(current_content).strip())
+        return headings
+
+    def generate_flashcards(self):
+        definitions = defaultdict(list)
+        for concept, sections in self.parse_notes().items():
+            for text in sections:
+                if concept in definitions and text not in definitions[concept]:
+                    self.log_messages.append(f"Ambiguity detected for '{concept}' with differing definitions.")
+                definitions[concept].append(text)
+                self.flashcards.append({'concept': concept, 'definition': text})
+        return self.flashcards
+
+    def export_json(self, output: Path):
+        output.write_text(json.dumps(self.flashcards, indent=2), encoding='utf-8')
+
+    def export_md(self, output: Path):
+        with output.open('w', encoding='utf-8') as f:
+            for card in self.flashcards:
+                f.write(f"### {card['concept']}\n{card['definition']}\n\n")
+
+    def summarize(self):
+        summary = {}
+        for concept, defs in self.parse_notes().items():
+            summary[concept] = defs[0][:100] + ('...' if len(defs[0]) > 100 else '')
+        return summary
+
+    def print_log(self):
+        for msg in self.log_messages:
+            print(msg)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='FlashAgent CLI')
+    subparsers = parser.add_subparsers(dest='command')
+
+    subparsers.add_parser('summarize')
+    subparsers.add_parser('generate')
+    subparsers.add_parser('export')
+
+    parser.add_argument('--notes', default='notes', help='Path to notes directory')
+    parser.add_argument('--json', default='flashcards.json', help='Output JSON file')
+    parser.add_argument('--md', default='flashcards.md', help='Output Markdown file')
+
+    args = parser.parse_args()
+    agent = FlashAgent(Path(args.notes))
+
+    if args.command == 'summarize':
+        summary = agent.summarize()
+        print(json.dumps(summary, indent=2))
+    elif args.command == 'generate':
+        agent.generate_flashcards()
+        agent.print_log()
+        print(json.dumps(agent.flashcards, indent=2))
+    elif args.command == 'export':
+        agent.generate_flashcards()
+        agent.export_json(Path(args.json))
+        agent.export_md(Path(args.md))
+        agent.print_log()
+        print(f"Exported {len(agent.flashcards)} flashcards to {args.json} and {args.md}")
+    else:
+        parser.print_help()
+
+if __name__ == '__main__':
+    main()

--- a/flash_agent.py
+++ b/flash_agent.py
@@ -14,7 +14,12 @@ class FlashAgent:
         for path in self.notes_dir.rglob('*.md'):
             current_heading = None
             current_content = []
-            for line in path.read_text(encoding='utf-8').splitlines():
+            try:
+                lines = path.read_text(encoding='utf-8').splitlines()
+            except Exception as e:
+                self.log_messages.append(f"Warning: Could not read file {path}: {e}")
+                continue
+            for line in lines:
                 if line.startswith('#'):
                     if current_heading is not None:
                         headings[current_heading].append('\n'.join(current_content).strip())

--- a/notes/example.md
+++ b/notes/example.md
@@ -1,0 +1,10 @@
+# Quantum Computing
+Quantum computing uses quantum bits (qubits) which can be in superpositions.
+## Entanglement
+Entanglement allows qubits to be correlated in ways impossible in classical systems.
+## Superposition
+Superposition enables simultaneous computation of multiple states.
+# Machine Learning
+Machine learning algorithms learn from data.
+## Supervised Learning
+Data is labeled and algorithms learn a mapping from inputs to outputs.


### PR DESCRIPTION
## Summary
- create example notes in `notes/`
- implement `flash_agent.py` with CLI to parse notes and generate flashcards

## Testing
- `pytest -q`
- `python3 flash_agent.py summarize`
- `python3 flash_agent.py generate`
- `python3 flash_agent.py --json flashcards.json --md flashcards.md export`


------
https://chatgpt.com/codex/tasks/task_e_688143a22a74832baacb11f10ed20f65

## Summary by Sourcery

Introduce a FlashAgent tool that processes markdown notes into structured flashcards, supports summarization and ambiguous definition detection, and can export results as JSON or Markdown.

New Features:
- Introduce FlashAgent CLI to parse markdown notes and generate flashcards
- Add summarize, generate, and export commands with JSON and Markdown output
- Implement detection and logging of ambiguous concept definitions
- Include example markdown notes in the notes/ directory for use with the FlashAgent